### PR TITLE
Update from Original

### DIFF
--- a/einsatzkomponente.xml
+++ b/einsatzkomponente.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="component" version="1.6.0" method="upgrade">
     <name>com_einsatzkomponente</name>
-    <creationDate>2015-05-06</creationDate>
+    <creationDate>2015-05-11</creationDate>
     <copyright>Copyright (C) 2013 by Ralf Meyer. All rights reserved.</copyright>
     <license>GNU General Public License version 2 or later</license>
     <author>Ralf Meyer</author>

--- a/site/views/organisation/view.html.php
+++ b/site/views/organisation/view.html.php
@@ -36,7 +36,7 @@ class EinsatzkomponenteViewOrganisation extends JViewLegacy {
    		$this->form		= $this->get('Form');
 		$this->gmap_config = EinsatzkomponenteHelper::load_gmap_config(); // GMap-Config aus helper laden 
         //print_r ($this->item);break;
-		$this->orga_fahrzeuge = EinsatzkomponenteHelper::getOrga_fahrzeuge($this->item->name);  
+		$this->orga_fahrzeuge = EinsatzkomponenteHelper::getOrga_fahrzeuge($this->item->id);  
 	    $document = JFactory::getDocument();
 
 		


### PR DESCRIPTION
Bufix von Weezle:
Behebt Bug

http://www.einsatzkomponente.de/wpbt/index.php/Issue/112-in-der-Organisation-die-Fahrzeug-anzeige-bleibt-leer/

Hier war noch von früher der Name der Organisation angegeben. Die neuen
SQLs jedoch benötigen die ID. Ist hiermit korrigiert und getestet.
